### PR TITLE
Add Long Beach, Calif. to list of cities using this spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 * [Philadelphia](https://github.com/CityOfPhiladelphia/flu-shot-spec)
 * [Chicago](https://data.cityofchicago.org/developers/docs/flu-shot-clinic-locations-2013)
 * [San Francisco](https://data.sfgov.org/Public-Health/San-Francisco-Department-of-Public-Health-Flu-Shot/yg87-cd6v)
+* [Long Beach, Calif.](https://www.google.com/fusiontables/DataSource?docid=1n5PNdxLZu9-neTWzfpnpGknTv3rntZ99IMUPpiM)
 
 ##Using / Contributing
 


### PR DESCRIPTION
For [lbcflushots.org](http://www.lbcflushots.org), Long Beach, Calif. is now publishing flu shot locations in a [Google Fusion table](https://www.google.com/fusiontables/DataSource?docid=1n5PNdxLZu9-neTWzfpnpGknTv3rntZ99IMUPpiM#rows:id=1) formatted in accordance with this spec. This pull request adds Long Beach to the list of cities using this spec.
